### PR TITLE
Detect DataViews and retrieve their data object.

### DIFF
--- a/src/slick.autocolumnsize.js
+++ b/src/slick.autocolumnsize.js
@@ -79,6 +79,7 @@
             var texts = [];
             var rowEl = createRow(columnDef);
             var data = grid.getData();
+            if (data instanceof Slick.Data.DataView) data = data.getItems();
 
             for (var i = 0; i < data.length; i++) {
                 texts.push(data[i][columnDef.field]);


### PR DESCRIPTION
This will allow the column autosize plugin to work with DataViews that have simple data structures that resemble the default rows object, which is probably most of them.  Without this, the plugin will not read any of the data values when checking text size and will autosize to the column header.
