### PR TITLE
Fixed getMaxTextTemplate with column formatter

### DIFF
--- a/src/slick.autocolumnsize.js
+++ b/src/slick.autocolumnsize.js
@@ -105,7 +105,7 @@
             $(texts).each(function(index, text) {
                 var template;
                 if (formatFun) {
-                    template = $("<span>" + formatFun(index, colIndex, text, columnDef, data) + "</span>");
+                    template = $("<span>" + formatFun(index, colIndex, text, columnDef, data[index]) + "</span>");
                     text = template.text() || text;
                 }
                 var length = text ? getElementWidthUsingCanvas(rowEl, text) : 0;


### PR DESCRIPTION
In getMaxTextTemplate, pass the actual object to the column formatter and not the whole array of objects
