### PR TITLE
Slick.Data.DataView is not required and therefore might not always be…

### DIFF
--- a/src/slick.autocolumnsize.js
+++ b/src/slick.autocolumnsize.js
@@ -79,8 +79,10 @@
             var texts = [];
             var rowEl = createRow(columnDef);
             var data = grid.getData();
-            if (Slick.Data && data instanceof Slick.Data.DataView) {
-                data = data.getItems();
+            if (typeof(Slick.Data.DataView) == "function") {
+                if (Slick.Data && data instanceof Slick.Data.DataView) {
+                    data = data.getItems();
+                }
             }
             for (var i = 0; i < data.length; i++) {
                 texts.push(data[i][columnDef.field]);

--- a/src/slick.autocolumnsize.js
+++ b/src/slick.autocolumnsize.js
@@ -85,7 +85,9 @@
                 }
             }
             for (var i = 0; i < data.length; i++) {
-                texts.push(data[i][columnDef.field]);
+                if (data[i]) {
+                    texts.push(data[i][columnDef.field]);
+                }
             }
             var template = getMaxTextTemplate(texts, columnDef, colIndex, data, rowEl);
             var width = getTemplateWidth(rowEl, template);


### PR DESCRIPTION
Slick.Data.DataView is not required and may not be present in all projects (like the one I'm working on). This was causing the following error: TypeError: Right hand side of instanceof is not an object. I'm not checking that Slick.Data.DataView is a function before calling instanceof. Also, data[i] is sometimes undefined; needed to check for presence before trying to use it.